### PR TITLE
Skip Claude code review when commit is from Claude

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,8 +31,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Get current commit author
+        id: get_author
+        run: |
+          AUTHOR=$(git log -1 --pretty=format:'%an')
+          echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+
       - name: Run Claude Code Review
         id: claude-review
+        if: ${{ steps.get_author.outputs.author != 'claude' }}
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
- Add a step to get current commit author
- Only run the Claude Code Review if the author is not Claude